### PR TITLE
Build test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .pypirc
 SECURE.txt
-test*.py
+test.py
+test_advanced.py
 client_secret.json
 *.pyc
 quickstart.py

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ built_docs
 build_docs.sh
 *.csv
 commitnotes
+.cache
+secure
+shawk.egg-info

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="https://raw.githubusercontent.com/hawkins/shawk/master/shawk.png" width="64" height="64"</img> Shawk - Free SMS with Python using SMTP and IMAP
 
-A python `smtplib` and `imapclient` wrapper to send and receive SMS messages through SMS gateways with a Gmail login.
-Perfect for Internet of Things projects that use a Raspberry Pi to text you!
+A Python `smtplib` and `imapclient` wrapper to send and receive SMS messages through SMS gateways with a Gmail login.
+Perfect for Internet of Things projects that use a Raspberry Pi to text you.
 
 
 ##### Disclaimer
@@ -14,12 +14,29 @@ Perfect for Internet of Things projects that use a Raspberry Pi to text you!
 Shawk is available on PyPi as such:
 
 ```
-pip install shawk
+pip install -U shawk
 ```
+
 
 # Documentation
 
 To see full documentation and a more detailed Getting Started page, [see here](https://shawk.readthedocs.io/en/latest/Getting%20Started.html).
+
+
+# Contributing
+
+I welcome all sorts of contributions - code, docs, tests, bugs, etc.
+If you'd like to contribute code, please make sure your tests continue to pass after making your changes.
+Additionally, if your new code requires any testing, please write your tests in the appropriate file.
+
+
+## Testing
+
+Tests can be run with Pytest.
+
+1. Run `pip install -U pytest` to install pytest
+2. Locally install this Shawk package with `pip install -e .`
+3. Then simply run `pytest` in the root directory to execute tests
 
 
 # Simple Usage Example

--- a/docs/Getting Started.rst
+++ b/docs/Getting Started.rst
@@ -101,12 +101,9 @@ We can get the new ones manually by first setting up our inbox and refreshing it
 .. code-block:: python
 
     client.setup_inbox(password) # We don't save your password, so send it again
-    client.refresh_inbox()
+    client.refresh()
 
-    # or...
-    client.setup_inbox(password, refresh=True)
-
-This will handle the IMAP server connection for retrieving new messages to your Gmail account.
+This will handle establishing the IMAP server connection for retrieving new messages to your Gmail account and manually retrieving the messages afterwards.
 
 You can actually use a distinct Gmail account from the one you use to send messages by passing a user: string, but we won't focus on that for this simple tutorial.
 As always, read the rest of the docs if you'd like to know more about that.

--- a/test/SpoofPhone.py
+++ b/test/SpoofPhone.py
@@ -1,0 +1,31 @@
+
+from datetime import datetime
+from collections import defaultdict
+
+class SpoofPhone():
+    """This class provides methods to spoof tools to spoof SMS messages to a Shawk client"""
+
+    def __init__(self, mock_IMAP_instance, sender):
+        self.imap = mock_IMAP_instance
+        self.sender = sender
+
+    def send(self, messages, time=None, sender=None):
+        """Spoof a simple SMS"""
+
+        # Handle arguments
+        if not time:
+            time = datetime.utcnow()
+        if not sender:
+            sender = self.sender
+        if not isinstance(messages, list):
+            messages = [messages]
+
+        # Spoof IMAP's fetch return value
+        self.imap.fetch.return_value = defaultdict(dict)
+        message_counter = 1
+        for message in messages:
+            self.imap.fetch.return_value[message_counter] = {
+                b'BODY[TEXT]': str.encode(message),
+                b'BODY[HEADER.FIELDS (FROM)]': str.encode(sender.get_address()),
+                b'INTERNALDATE': str.encode(str(time))
+            }

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,5 @@
+"""Define the test tooling"""
+
+from test.SpoofPhone import SpoofPhone
+
+__name__ = "test"

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,0 +1,374 @@
+
+import shawk
+from test import SpoofPhone
+from mock import patch, call
+from copy import deepcopy
+from time import sleep
+from datetime import datetime
+import re
+
+# Prepare client variables
+username = 'username@email.com'
+password = 'password'
+
+#
+# Test adding and removing contacts
+#
+
+@patch('smtplib.SMTP')
+def test_creating_a_client(mock_SMTP):
+    """Test creating a client"""
+
+    client = shawk.Client(username, password)
+    assert(type(client) == shawk.Client)
+    assert(str(client) == 'A Shawk SMS Client for username@email.com')
+
+@patch('smtplib.SMTP')
+def test_add_contact_minimal(mock_SMTP):
+    """Test adding a contact without a name"""
+
+    client = shawk.Client(username, password)
+    contacts_before = deepcopy(client.contacts)
+
+    client.add_contact(number=1234567890, carrier='Verizon')
+    contacts_after = client.contacts
+    assert(contacts_before != contacts_after)
+    assert(str(contacts_after) == "{'1234567890': <shawk.Contact('1234567890', 'Verizon', '<No name>')>}")
+
+@patch('smtplib.SMTP')
+def test_add_contact_with_name(mock_SMTP):
+    """Test adding a contact with a name"""
+
+    client = shawk.Client(username, password)
+    contacts_before = deepcopy(client.contacts)
+
+    client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+    contacts_after = client.contacts
+    assert(contacts_before != contacts_after)
+    assert(str(contacts_after) == "{'1234567890': <shawk.Contact('1234567890', 'Verizon', 'Somebody')>}")
+
+@patch('smtplib.SMTP')
+def test_remove_contact_by_number(mock_SMTP):
+    """Test removing a contact by specifying its number"""
+
+    client = shawk.Client(username, password)
+    client.add_contact(number=1234567890, carrier='Verizon')
+    contacts_before = deepcopy(client.contacts)
+
+    client.remove_contact(number=1234567890)
+    contacts_after = client.contacts
+    assert(contacts_before != contacts_after)
+    assert(contacts_after == {})
+
+@patch('smtplib.SMTP')
+def test_remove_contact_by_name(mock_SMTP):
+    """Test removing a contact by specifying its name"""
+
+    client = shawk.Client(username, password)
+    client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+    contacts_before = deepcopy(client.contacts)
+
+    client.remove_contact(name='Somebody')
+    contacts_after = client.contacts
+    assert(contacts_before != contacts_after)
+    assert(contacts_after == {})
+
+@patch('smtplib.SMTP')
+def test_remove_contact_by_contact(mock_SMTP):
+    """Test removing a contact by specifying its Contact"""
+
+    client = shawk.Client(username, password)
+    contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+    contacts_before = deepcopy(client.contacts)
+
+    client.remove_contact(contact=contact)
+    contacts_after = client.contacts
+    assert(contacts_before != contacts_after)
+    assert(contacts_after == {})
+
+#
+# Test sending messages
+#
+
+@patch('smtplib.SMTP')
+def test_send_message_by_contact(mock_SMTP):
+    """Test sending a message to a Contact"""
+
+    client = shawk.Client(username, password)
+    contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+    address = contact.get_address()
+    message = 'Testing'
+
+    client.send(message, contact=contact)
+    instance = mock_SMTP.return_value
+    assert(instance.sendmail.call_count == 1)
+    assert(instance.sendmail.mock_calls == [call('0', address, message)])
+
+@patch('smtplib.SMTP')
+def test_send_message_by_number(mock_SMTP):
+    """Test sending a message to a number"""
+
+    client = shawk.Client(username, password)
+    number = 1234567890
+    contact = client.add_contact(number=number, carrier='Verizon', name='Somebody')
+    address = contact.get_address()
+    message = 'Testing'
+
+    client.send(message, number=number)
+    instance = mock_SMTP.return_value
+    assert(instance.sendmail.call_count == 1)
+    assert(instance.sendmail.mock_calls == [call('0', address, message)])
+
+@patch('smtplib.SMTP')
+def test_send_message_by_namer(mock_SMTP):
+    """Test sending a message to a name"""
+
+    client = shawk.Client(username, password)
+    name = 'Somebody'
+    contact = client.add_contact(number=1234567890, carrier='Verizon', name=name)
+    address = contact.get_address()
+    message = 'Testing'
+
+    client.send(message, name=name)
+    instance = mock_SMTP.return_value
+    assert(instance.sendmail.call_count == 1)
+    assert(instance.sendmail.mock_calls == [call('0', address, message)])
+
+@patch('smtplib.SMTP')
+def test_send_message_by_address(mock_SMTP):
+    """Test sending a message to an address"""
+
+    client = shawk.Client(username, password)
+    contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+    address = contact.get_address()
+    message = 'Testing'
+
+    client.send(message, address=address)
+    instance = mock_SMTP.return_value
+    assert(instance.sendmail.call_count == 1)
+    assert(instance.sendmail.mock_calls == [call('0', address, message)])
+
+#
+# Test receiving messages
+#
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_receiving_messages_manually(mock_IMAP, mock_SMTP):
+    """Test receiving a simple text message"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    imap_instance = client.imap
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(imap_instance, spoof_contact)
+    message_time = datetime.utcnow()
+    spoof_phone.send('Testing', message_time)
+
+    client.refresh()
+
+    assert(imap_instance.copy.call_count == 1)
+    assert(str(client.inbox) == str([shawk.Message('Testing', spoof_phone.sender, message_time)]))
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_receiving_messages_automatically(mock_IMAP, mock_SMTP):
+    """Test receiving a simple text message automatically"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password, auto=True)
+    imap_instance = client.imap
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(imap_instance, spoof_contact)
+    message_time = datetime.utcnow()
+    spoof_phone.send('Testing', message_time)
+
+    # TODO: How best should we wait for this?
+    sleep(max(3, 2 * client.refresh_interval))
+    assert(imap_instance.copy.call_count == 1)
+    assert(str(client.inbox) == str([shawk.Message('Testing', spoof_phone.sender, message_time)]))
+
+#
+# Test text handler functions
+#
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_adding_default_text_handler_via_decorator(mock_IMAP, mock_SMTP):
+    """Test adding a default text handler and verify that it replaces the stock handler"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {} # HACK: Ugly way to avoid closure non-local scope issues in Python 2
+
+    @client.text_handler()
+    def decorated_default_text_handler(client, message):
+        context['did_call_decorated_default_text_handler'] = True
+
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(context['did_call_decorated_default_text_handler'])
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_adding_default_text_handler_via_function(mock_IMAP, mock_SMTP):
+    """Test adding a default text handler and verify that it replaces the stock handler"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {}
+
+    def default_text_handler(client, message):
+        context['did_call_default_text_handler'] = True
+
+    client.set_default_text_handler(default_text_handler)
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(context['did_call_default_text_handler'])
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_adding_text_handler_via_function(mock_IMAP, mock_SMTP):
+    """Test adding a text handler with regex via function"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {}
+
+    def text_handler(client, message, match, regex):
+        context['did_call_text_handler'] = True
+
+    client.add_text_handler(re.compile('Testing'), text_handler)
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(context['did_call_text_handler'])
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_adding_text_handler_via_decorator_without_flags(mock_IMAP, mock_SMTP):
+    """Test adding a text handler with regex via decorator without flags"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {}
+
+    @client.text_handler('Testing')
+    def text_handler(client, message, match, regex):
+        context['did_call_text_handler'] = True
+
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(context['did_call_text_handler'])
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_adding_text_handler_via_decorator_with_flags(mock_IMAP, mock_SMTP):
+    """Test adding a text handler with regex via decorator with flags"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {}
+
+    @client.text_handler('testing', 'i')
+    def text_handler(client, message, match, regex):
+        context['did_call_text_handler'] = True
+
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(context['did_call_text_handler'])
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_removing_text_handler(mock_IMAP, mock_SMTP):
+    """Test removing a text handler"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {}
+
+    def text_handler(client, message, match, regex):
+        context['did_call_text_handler'] = True
+
+    regex = re.compile('Testing')
+    client.add_text_handler(regex, text_handler)
+    client.remove_text_handler(regex, text_handler)
+
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(not context.get('did_call_text_handler', False))
+
+#
+# Test contact handler functions
+#
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_adding_contact_handler_via_decorator(mock_IMAP, mock_SMTP):
+    """Test adding a contact handler"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {}
+
+    @client.contact_handler(spoof_contact)
+    def decorated_contact_handler(client, message):
+        context['did_call_decorated_contact_handler'] = True
+
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(context['did_call_decorated_contact_handler'])
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_adding_contact_handler_via_function(mock_IMAP, mock_SMTP):
+    """Test adding a contact handler via function"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {}
+
+    def contact_handler(client, message):
+        context['did_call_contact_handler'] = True
+
+    client.add_contact_handler(spoof_contact, contact_handler)
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(context['did_call_contact_handler'])
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_removing_contact_handler(mock_IMAP, mock_SMTP):
+    """Test removing a contact handler"""
+
+    client = shawk.Client(username, password)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    context = {}
+
+    def contact_handler(client, message):
+        context['did_call_text_handler'] = True
+
+    regex = re.compile('Testing')
+    client.add_contact_handler(spoof_contact, contact_handler)
+    client.remove_text_handler(spoof_contact, contact_handler)
+
+    spoof_phone.send('Testing')
+    client.refresh()
+    assert(not context.get('did_call_contact_handler', False))

--- a/test/test_contact.py
+++ b/test/test_contact.py
@@ -1,17 +1,13 @@
 
 # Import shawk
-import shawk
+from shawk import Contact
 
 # Prepare contacts used throughout tests
-mini_contact = shawk.Contact(12345678, 'Verizon')
-name_contact = shawk.Contact(12345678, 'Verizon', 'Somebody')
-
-
-""" BEGIN TESTS """
-
+mini_contact = Contact(12345678, 'Verizon')
+name_contact = Contact(12345678, 'Verizon', 'Somebody')
 
 def test_repr_minimal():
-    assert(repr(mini_contact) == "<shawk.Contact('12345678', 'Verizon', '<No name>')>") 
+    assert(repr(mini_contact) == "<shawk.Contact('12345678', 'Verizon', '<No name>')>")
 
 def test_repr_with_name():
     assert(repr(name_contact) == "<shawk.Contact('12345678', 'Verizon', 'Somebody')>")
@@ -25,11 +21,8 @@ def test_string_with_name():
 def test_get_address_verizon():
     assert(name_contact.get_address() == '12345678@vtext.com')
 
-# TODO: Ideally we would test every domain, right?
-
 def test_get_number():
     assert(name_contact.get_number() == '12345678')
 
 def test_get_name():
     assert(name_contact.get_name() == 'Somebody')
-

--- a/test/test_contact.py
+++ b/test/test_contact.py
@@ -1,0 +1,35 @@
+
+# Import shawk
+import shawk
+
+# Prepare contacts used throughout tests
+mini_contact = shawk.Contact(12345678, 'Verizon')
+name_contact = shawk.Contact(12345678, 'Verizon', 'Somebody')
+
+
+""" BEGIN TESTS """
+
+
+def test_repr_minimal():
+    assert(repr(mini_contact) == "<shawk.Contact('12345678', 'Verizon', '<No name>')>") 
+
+def test_repr_with_name():
+    assert(repr(name_contact) == "<shawk.Contact('12345678', 'Verizon', 'Somebody')>")
+
+def test_string_minimal():
+    assert(str(mini_contact) == '<No name>: 12345678 (Verizon)')
+
+def test_string_with_name():
+    assert(str(name_contact) == 'Somebody: 12345678 (Verizon)')
+
+def test_get_address_verizon():
+    assert(name_contact.get_address() == '12345678@vtext.com')
+
+# TODO: Ideally we would test every domain, right?
+
+def test_get_number():
+    assert(name_contact.get_number() == '12345678')
+
+def test_get_name():
+    assert(name_contact.get_name() == 'Somebody')
+

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -1,0 +1,34 @@
+
+# Import shawk
+import shawk
+
+# Prepare contacts used throughout tests
+name_contact = shawk.Contact(12345678, 'Verizon', 'Somebody')
+
+# Prepare messages
+mini_message = shawk.Message('Text', name_contact)
+date_message = shawk.Message('Text', name_contact, '2016-12-22 21:54:57')
+date_message_clone = shawk.Message('Text', name_contact, '2016-12-22 21:54:57')
+
+
+""" BEGIN TESTS """
+
+
+def test_repr_minimal():
+    assert(repr(mini_message) == "<shawk.Message('Text', 'Somebody: 12345678 (Verizon)')>")
+
+def test_repr_with_date():
+    assert(repr(date_message) == "<shawk.Message('Text', 'Somebody: 12345678 (Verizon)', '2016-12-22 21:54:57')>")
+
+def test_string_minimal():
+    assert(str(mini_message) == "Message from Somebody: 12345678 (Verizon) at None: \"Text\"")
+
+def test_string_with_date():
+    assert(str(date_message) == "Message from Somebody: 12345678 (Verizon) at 2016-12-22 21:54:57: \"Text\"")
+
+def test_not_eq():
+    assert(not (mini_message == date_message))
+
+def test_eq():
+    assert(date_message == date_message_clone)
+

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -1,18 +1,14 @@
 
 # Import shawk
-import shawk
+from shawk import Message, Contact
 
 # Prepare contacts used throughout tests
-name_contact = shawk.Contact(12345678, 'Verizon', 'Somebody')
+name_contact = Contact(12345678, 'Verizon', 'Somebody')
 
 # Prepare messages
-mini_message = shawk.Message('Text', name_contact)
-date_message = shawk.Message('Text', name_contact, '2016-12-22 21:54:57')
-date_message_clone = shawk.Message('Text', name_contact, '2016-12-22 21:54:57')
-
-
-""" BEGIN TESTS """
-
+mini_message = Message('Text', name_contact)
+date_message = Message('Text', name_contact, '2016-12-22 21:54:57')
+date_message_clone = Message('Text', name_contact, '2016-12-22 21:54:57')
 
 def test_repr_minimal():
     assert(repr(mini_message) == "<shawk.Message('Text', 'Somebody: 12345678 (Verizon)')>")
@@ -31,4 +27,3 @@ def test_not_eq():
 
 def test_eq():
     assert(date_message == date_message_clone)
-


### PR DESCRIPTION
Fixes #10 

Wound up ditching the MiniMock idea in exchange for the standard library's `mock` module to patch SMTP and IMAP interfaces.

Tests are written in the `/test` folder.
They can be ran using `$ pytest`.

Spoofs an IMAP interface to the extent of receiving messages only.
Additionally, `__sendmail()` was not disabled, but instead we simply inspect the calls made to it.


#### Further improvement

One area this test suite could improve in is expecting more failures.
Currently, it tends to test scenarios in which Shawk should work, but it does not test areas where Shawk should not work well yet.

For instance,

- Creating a Contact with `name="<No name>"` should not be allowed
- Creating / removing handlers where `handler=something` where `something` is not a function should not be allowed
- Etc etc

These tests could be added later, though, since areas where Shawk should fail will become more apparent as the API stabilizes.