### PR TITLE
Add emoji support

### DIFF
--- a/docs/Using Emoji.rst
+++ b/docs/Using Emoji.rst
@@ -1,0 +1,53 @@
+Using Emoji
+===========
+
+Syntax
+------
+
+Using Emoji in Shawk is pretty straightforward.
+Since Shawk utilizies the Emoji library on PyPi, the entire set of Emoji codes as defined by the `unicode consortium <http://www.unicode.org/Public/emoji/1.0/full-emoji-list.html>`_ is supported in addition to a bunch of `aliases <http://www.emoji-cheat-sheet.com/>`_.
+
+Unlike the Emoji library, we allow all aliases at all times.
+This means that you can say either ":thumbs_up_sign:" or ":thumbsup:" to insert the thumbs up emoji in your text messages.
+
+
+Configuring
+-----------
+
+By default, both "demojizing" and "emojizing" are enabled.
+This means that when you receive a text message, it is "demojized", or emojis are translated to :: syntax, and sent messages are translated from :: syntax to unicode emojis.
+
+To disable emojizing / demojizing, you can run the following code:
+
+.. code-block:: python
+
+    # Disable demojizing
+    client.disable_demojize()
+
+    # Disable emojizing
+    client.disable_emojize()
+
+You can similarly re-enable either setting:
+
+.. code-block:: python
+
+    # Re-enable demojizing
+    client.enable_demojize()
+
+    # Re-enable emojizing
+    client.enable_emojize()
+
+
+Example
+-------
+
+Since emojizing is enabled by default, sending an emojized message is as simple as this:
+
+.. code-block:: python
+
+    # Create and configure client
+    client = shawk.Client(username, password)
+    contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+
+    # Send the message
+    client.send('Testing :thumbs_up_sign:', contact=contact)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Module Index
 
    Getting Started
    Configuring Gmail
+   Using Emoji
    Client
    Contact
    Message

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(
     classifiers = [],
     install_requires=[
         'imapclient>=1.0.2',
+        'emoji>=0.3.9',
     ],
 )

--- a/shawk/Client.py
+++ b/shawk/Client.py
@@ -513,16 +513,23 @@ class Client(object):
         for _, contact in self.contacts.items():
             print(contact)
 
-    def __sendmail(self, address, text):
+    def __sendmail(self, address, text, emojize=None):
         """Send the content of message to address"""
 
-        if self.emojize:
-            text = emoji.emojize(text, use_aliases=True)
+        # Check if emojize was specified
+        if emojize is not None:
+            # If so, follow its rule
+            if emojize:
+                text = emoji.emojize(text, use_aliases=True)
+        else:
+            # Otherwise, follow client rule
+            if self.emojize:
+                text = emoji.emojize(text, use_aliases=True)
 
         return self.smtp.sendmail('0', address, text)
 
 
-    def send(self, message, contact=None, address=None, number=None, name=None, carrier=None):
+    def send(self, message, contact=None, address=None, number=None, name=None, carrier=None, emojize=None):
         """
         Send a message.
 
@@ -544,9 +551,9 @@ class Client(object):
 
         # Send message to recipient
         if address:
-            return self.__sendmail(address, message)
+            return self.__sendmail(address, message, emojize=emojize)
         if contact:
-            return self.__sendmail(contact.get_address(), message)
+            return self.__sendmail(contact.get_address(), message, emojize=emojize)
 
         # Address is not readily available, determine from other inputs
 
@@ -557,7 +564,7 @@ class Client(object):
             # Get address of recipient
             try:
                 address = self.contacts[number].get_address()
-                return self.__sendmail(address, message)
+                return self.__sendmail(address, message, emojize=emojize)
             except KeyError:
                 # Number not in contacts
                 if not carrier:
@@ -567,7 +574,7 @@ class Client(object):
                     # Build address
                     address = sms_to_mail(number, carrier)
                     # Send the message
-                    return self.__sendmail(address, message)
+                    return self.__sendmail(address, message, emojize=emojize)
 
         # Find address if only given name
         if name and not address:
@@ -577,7 +584,7 @@ class Client(object):
                     address = each.get_address()
 
                     # Send the message
-                    return self.__sendmail(address, message)
+                    return self.__sendmail(address, message, emojize=emojize)
 
             if not number:
                 # Name was not found in contacts

--- a/shawk/Client.py
+++ b/shawk/Client.py
@@ -22,7 +22,7 @@ from shawk import SMS_Address_Regex, sms_to_mail
 class Client(object):
     """Client is the main Shawk interface"""
 
-    def __init__(self, user, password, emojize=True, demojize=True):
+    def __init__(self, user, password):
         """
         Initialize the client and configure SMTP for sending messages.
 
@@ -39,8 +39,8 @@ class Client(object):
         self.auto_refresh_enabled = False
         self.text_handlers = {}
         self.contact_handlers = {}
-        self.emojize = emojize
-        self.demojize = demojize
+        self.emojize = True
+        self.demojize = True
 
         # Configure SMTP
         self.setup_outbox("smtp.gmail.com", 587, user, password)
@@ -63,6 +63,26 @@ class Client(object):
             self.imap.logout()
         except AttributeError:
             pass
+
+    def enable_emojize(self):
+        """Enable translating text to emojis when sending messages"""
+
+        self.emojize = True
+
+    def disable_emojize(self):
+        """Disable translating text to emojis when sending messages"""
+
+        self.emojize = False
+
+    def enable_demojize(self):
+        """Enable translating emojis to text when receiving messages"""
+
+        self.demojize = True
+
+    def disable_demojize(self):
+        """Disable translating text to emojis when receiving messages"""
+
+        self.demojize = False
 
     def add_contact(self, number, carrier, name=None):
         """

--- a/test/SpoofPhone.py
+++ b/test/SpoofPhone.py
@@ -1,6 +1,7 @@
 
 from datetime import datetime
 from collections import defaultdict
+import emoji
 
 class SpoofPhone():
     """This class provides methods to spoof tools to spoof SMS messages to a Shawk client"""
@@ -9,7 +10,7 @@ class SpoofPhone():
         self.imap = mock_IMAP_instance
         self.sender = sender
 
-    def send(self, messages, time=None, sender=None):
+    def send(self, messages, time=None, sender=None, emojize=False):
         """Spoof a simple SMS"""
 
         # Handle arguments
@@ -19,6 +20,8 @@ class SpoofPhone():
             sender = self.sender
         if not isinstance(messages, list):
             messages = [messages]
+        if emojize:
+            messages = [emoji.emojize(message, use_aliases=True) for message in messages]
 
         # Spoof IMAP's fetch return value
         self.imap.fetch.return_value = defaultdict(dict)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -402,7 +402,7 @@ def test_removing_contact_handler(mock_IMAP, mock_SMTP):
 def test_sending_emoji_message(mock_SMTP):
     """Test sending a message with emoji"""
 
-    client = shawk.Client(username, password, emojize=True)
+    client = shawk.Client(username, password)
     contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
     smtp_instance = mock_SMTP.return_value
     address = contact.get_address()
@@ -417,7 +417,8 @@ def test_sending_emoji_message(mock_SMTP):
 def test_sending_message_without_translating_emoji(mock_SMTP):
     """Test sending a message with emoji code but without emojizing it"""
 
-    client = shawk.Client(username, password, emojize=False)
+    client = shawk.Client(username, password)
+    client.disable_emojize()
     contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
     smtp_instance = mock_SMTP.return_value
     address = contact.get_address()
@@ -433,7 +434,8 @@ def test_sending_message_without_translating_emoji(mock_SMTP):
 def test_receiving_emoji_message(mock_IMAP, mock_SMTP):
     """Test receiving a message with emoji"""
 
-    client = shawk.Client(username, password, demojize=False)
+    client = shawk.Client(username, password)
+    client.disable_demojize()
     client.setup_inbox(password)
     spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
     spoof_phone = SpoofPhone(client.imap, spoof_contact)
@@ -452,7 +454,7 @@ def test_receiving_emoji_message(mock_IMAP, mock_SMTP):
 def test_receiving_emoji_message_demojized(mock_IMAP, mock_SMTP):
     """Test receiving a message with emoji translated back to text"""
 
-    client = shawk.Client(username, password, demojize=True)
+    client = shawk.Client(username, password)
     client.setup_inbox(password)
     spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
     spoof_phone = SpoofPhone(client.imap, spoof_contact)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -414,6 +414,22 @@ def test_sending_emoji_message(mock_SMTP):
     assert(smtp_instance.sendmail.mock_calls == [call('0', address, emoji.emojize(message))])
 
 @patch('smtplib.SMTP')
+def test_sending_emoji_message_via_send_emojize(mock_SMTP):
+    """Test sending a message with emoji by passing emojize=True to send"""
+
+    client = shawk.Client(username, password)
+    client.disable_emojize()
+    contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+    smtp_instance = mock_SMTP.return_value
+    address = contact.get_address()
+    message = 'Testing :thumbs_up_sign:'
+
+    client.send(message, contact=contact, emojize=True)
+
+    assert(smtp_instance.sendmail.call_count == 1)
+    assert(smtp_instance.sendmail.mock_calls == [call('0', address, emoji.emojize(message))])
+
+@patch('smtplib.SMTP')
 def test_sending_message_without_translating_emoji(mock_SMTP):
     """Test sending a message with emoji code but without emojizing it"""
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,11 +1,13 @@
 
-import shawk
-from test import SpoofPhone
 from mock import patch, call
 from copy import deepcopy
 from time import sleep
 from datetime import datetime
 import re
+import emoji
+
+import shawk
+from test import SpoofPhone
 
 # Prepare client variables
 username = 'username@email.com'
@@ -20,6 +22,7 @@ def test_creating_a_client(mock_SMTP):
     """Test creating a client"""
 
     client = shawk.Client(username, password)
+
     assert(type(client) == shawk.Client)
     assert(str(client) == 'A Shawk SMS Client for username@email.com')
 
@@ -32,6 +35,7 @@ def test_add_contact_minimal(mock_SMTP):
 
     client.add_contact(number=1234567890, carrier='Verizon')
     contacts_after = client.contacts
+
     assert(contacts_before != contacts_after)
     assert(str(contacts_after) == "{'1234567890': <shawk.Contact('1234567890', 'Verizon', '<No name>')>}")
 
@@ -44,6 +48,7 @@ def test_add_contact_with_name(mock_SMTP):
 
     client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
     contacts_after = client.contacts
+
     assert(contacts_before != contacts_after)
     assert(str(contacts_after) == "{'1234567890': <shawk.Contact('1234567890', 'Verizon', 'Somebody')>}")
 
@@ -57,6 +62,7 @@ def test_remove_contact_by_number(mock_SMTP):
 
     client.remove_contact(number=1234567890)
     contacts_after = client.contacts
+
     assert(contacts_before != contacts_after)
     assert(contacts_after == {})
 
@@ -70,6 +76,7 @@ def test_remove_contact_by_name(mock_SMTP):
 
     client.remove_contact(name='Somebody')
     contacts_after = client.contacts
+
     assert(contacts_before != contacts_after)
     assert(contacts_after == {})
 
@@ -83,6 +90,7 @@ def test_remove_contact_by_contact(mock_SMTP):
 
     client.remove_contact(contact=contact)
     contacts_after = client.contacts
+
     assert(contacts_before != contacts_after)
     assert(contacts_after == {})
 
@@ -101,6 +109,7 @@ def test_send_message_by_contact(mock_SMTP):
 
     client.send(message, contact=contact)
     instance = mock_SMTP.return_value
+
     assert(instance.sendmail.call_count == 1)
     assert(instance.sendmail.mock_calls == [call('0', address, message)])
 
@@ -116,6 +125,7 @@ def test_send_message_by_number(mock_SMTP):
 
     client.send(message, number=number)
     instance = mock_SMTP.return_value
+
     assert(instance.sendmail.call_count == 1)
     assert(instance.sendmail.mock_calls == [call('0', address, message)])
 
@@ -131,6 +141,7 @@ def test_send_message_by_namer(mock_SMTP):
 
     client.send(message, name=name)
     instance = mock_SMTP.return_value
+
     assert(instance.sendmail.call_count == 1)
     assert(instance.sendmail.mock_calls == [call('0', address, message)])
 
@@ -145,6 +156,7 @@ def test_send_message_by_address(mock_SMTP):
 
     client.send(message, address=address)
     instance = mock_SMTP.return_value
+
     assert(instance.sendmail.call_count == 1)
     assert(instance.sendmail.mock_calls == [call('0', address, message)])
 
@@ -185,6 +197,7 @@ def test_receiving_messages_automatically(mock_IMAP, mock_SMTP):
 
     # TODO: How best should we wait for this?
     sleep(max(3, 2 * client.refresh_interval))
+
     assert(imap_instance.copy.call_count == 1)
     assert(str(client.inbox) == str([shawk.Message('Testing', spoof_phone.sender, message_time)]))
 
@@ -209,6 +222,7 @@ def test_adding_default_text_handler_via_decorator(mock_IMAP, mock_SMTP):
 
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(context['did_call_decorated_default_text_handler'])
 
 @patch('smtplib.SMTP')
@@ -228,6 +242,7 @@ def test_adding_default_text_handler_via_function(mock_IMAP, mock_SMTP):
     client.set_default_text_handler(default_text_handler)
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(context['did_call_default_text_handler'])
 
 @patch('smtplib.SMTP')
@@ -247,6 +262,7 @@ def test_adding_text_handler_via_function(mock_IMAP, mock_SMTP):
     client.add_text_handler(re.compile('Testing'), text_handler)
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(context['did_call_text_handler'])
 
 @patch('smtplib.SMTP')
@@ -266,6 +282,7 @@ def test_adding_text_handler_via_decorator_without_flags(mock_IMAP, mock_SMTP):
 
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(context['did_call_text_handler'])
 
 @patch('smtplib.SMTP')
@@ -285,6 +302,7 @@ def test_adding_text_handler_via_decorator_with_flags(mock_IMAP, mock_SMTP):
 
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(context['did_call_text_handler'])
 
 @patch('smtplib.SMTP')
@@ -307,6 +325,7 @@ def test_removing_text_handler(mock_IMAP, mock_SMTP):
 
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(not context.get('did_call_text_handler', False))
 
 #
@@ -330,6 +349,7 @@ def test_adding_contact_handler_via_decorator(mock_IMAP, mock_SMTP):
 
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(context['did_call_decorated_contact_handler'])
 
 @patch('smtplib.SMTP')
@@ -349,6 +369,7 @@ def test_adding_contact_handler_via_function(mock_IMAP, mock_SMTP):
     client.add_contact_handler(spoof_contact, contact_handler)
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(context['did_call_contact_handler'])
 
 @patch('smtplib.SMTP')
@@ -365,10 +386,82 @@ def test_removing_contact_handler(mock_IMAP, mock_SMTP):
     def contact_handler(client, message):
         context['did_call_text_handler'] = True
 
-    regex = re.compile('Testing')
     client.add_contact_handler(spoof_contact, contact_handler)
     client.remove_text_handler(spoof_contact, contact_handler)
 
     spoof_phone.send('Testing')
     client.refresh()
+
     assert(not context.get('did_call_contact_handler', False))
+
+#
+# Test emojis
+#
+
+@patch('smtplib.SMTP')
+def test_sending_emoji_message(mock_SMTP):
+    """Test sending a message with emoji"""
+
+    client = shawk.Client(username, password, emojize=True)
+    contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+    smtp_instance = mock_SMTP.return_value
+    address = contact.get_address()
+    message = 'Testing :thumbs_up_sign:'
+
+    client.send(message, contact=contact)
+
+    assert(smtp_instance.sendmail.call_count == 1)
+    assert(smtp_instance.sendmail.mock_calls == [call('0', address, emoji.emojize(message))])
+
+@patch('smtplib.SMTP')
+def test_sending_message_without_translating_emoji(mock_SMTP):
+    """Test sending a message with emoji code but without emojizing it"""
+
+    client = shawk.Client(username, password, emojize=False)
+    contact = client.add_contact(number=1234567890, carrier='Verizon', name='Somebody')
+    smtp_instance = mock_SMTP.return_value
+    address = contact.get_address()
+    message = 'Testing :thumbs_up_sign:'
+
+    client.send(message, contact=contact)
+
+    assert(smtp_instance.sendmail.call_count == 1)
+    assert(smtp_instance.sendmail.mock_calls == [call('0', address, message)])
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_receiving_emoji_message(mock_IMAP, mock_SMTP):
+    """Test receiving a message with emoji"""
+
+    client = shawk.Client(username, password, demojize=False)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    message_time = datetime.utcnow()
+    original = 'Testing :thumbs_up_sign:'
+    emojized = emoji.emojize(original, use_aliases=True)
+    spoof_phone.send(original, time=message_time, emojize=True)
+
+    client.refresh()
+
+    assert(client.imap.copy.call_count == 1)
+    assert(str(client.inbox) == str([shawk.Message(emojized, spoof_phone.sender, message_time)]))
+
+@patch('smtplib.SMTP')
+@patch('imapclient.IMAPClient')
+def test_receiving_emoji_message_demojized(mock_IMAP, mock_SMTP):
+    """Test receiving a message with emoji translated back to text"""
+
+    client = shawk.Client(username, password, demojize=True)
+    client.setup_inbox(password)
+    spoof_contact = client.add_contact(number=1234567890, carrier='Verizon', name='Spoof')
+    spoof_phone = SpoofPhone(client.imap, spoof_contact)
+    message_time = datetime.utcnow()
+    original = 'Testing :thumbs_up_sign:'
+    emojized = emoji.emojize(original, use_aliases=True)
+    spoof_phone.send(original, time=message_time, emojize=True)
+
+    client.refresh()
+
+    assert(client.imap.copy.call_count == 1)
+    assert(str(client.inbox) == str([shawk.Message(original, spoof_phone.sender, message_time)]))


### PR DESCRIPTION
Fixes #9 .

This adds emoji support via `emoji` and introduces new methods to configure whether inbound or outbound messages are `demojized`/`emojized` respectively.


#### Further improvement

One area this could be improved with is adding documentation examples and further explaining what `emojizing` and `demojizing` means.

Additionally, it would be nice to be able to `emojize` only a specific message when sending it, maybe via `send(..., emojize=True)` for instance.